### PR TITLE
Drop JSON3 dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,11 @@ version = "0.1.0"
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]
 Catalyst = "13"
 HTTP = "1.9.6"
 JSON = "0.21.4"
-JSON3 = "1.13.1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
It's not used.

Maybe should move to JSON3.
I have lost track as to what the best JSON package is in julia right now.
But that dependency should be added once it is actually switched over.
