### PR TITLE
Compatible with more versions of SymbolicUtils

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Catalyst = "13, 14"
 HTTP = "1.9.6"
 JSON = "0.21.4"
-SymbolicUtils = "1.7.1, 3.5"
+SymbolicUtils = "1.7.1, 2, 3"
 julia = "1.9"
 
 [extras]


### PR DESCRIPTION
I knowingly skipped compat with v2, when i added before, because I couldn't be bothered testing it.
Turns out that is the compat i specifically need for my project though.
So I just tested it.
To be precise i tested `v2.1.3`
but given it works on the last release of 1.x,
and the last release of 2.x that implies it works at least over that range.
Similar logic for why to all of 3