### PR TITLE
Interface compatibility: Support generic numeric types

### DIFF
--- a/src/Chemistry_functions.jl
+++ b/src/Chemistry_functions.jl
@@ -63,13 +63,13 @@ function moles_by_mass(compound, mass)
 end
 
 """
-    limiting_reagent(reaction::Reaction, masses::Array{Float64})
+    limiting_reagent(reaction::Reaction, masses::AbstractVector)
 
 Calculate the limiting reagent in the reaction given the masses of the reactants.
 
 """
 
-function limiting_reagent(reaction::Reaction, masses::Array{Float64})
+function limiting_reagent(reaction::Reaction, masses::AbstractVector)
     substrates = reaction.substrates
     n = length(substrates)
     @inbounds begin
@@ -87,12 +87,12 @@ function limiting_reagent(reaction::Reaction, masses::Array{Float64})
 end
 
 """
-    theoretical_yield(reaction::Reaction, masses::Array, product::Num)
+    theoretical_yield(reaction::Reaction, masses::AbstractVector, product::Num)
 
 Calculate the theoretical yield of the given species in the reaction given the masses of the reactants.
 """
 
-function theoretical_yield(reaction::Reaction, masses::Array, product::Num)
+function theoretical_yield(reaction::Reaction, masses::AbstractVector, product::Num)
     lr, m = limiting_reagent(reaction, masses)
     return m * molar_ratio(reaction, product, lr) * molecular_weight(product)
 end

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -1,0 +1,68 @@
+using Test
+using Catalyst
+using PubChem
+
+@testset "Type Genericity" begin
+    @variables t
+    @species Al(t), Cl2(t), AlCl3(t)
+    @attach_metadata Al
+    @attach_metadata Cl2
+    @attach_metadata AlCl3
+
+    reaction = Reaction(1.0, [Al, Cl2], [AlCl3], [2, 3], [2])
+
+    @testset "BigFloat support" begin
+        # Test limiting_reagent with BigFloat
+        masses_bf = BigFloat[2.80, 4.15]
+        lr, moles = limiting_reagent(reaction, masses_bf)
+        @test isequal(lr, Cl2)
+        @test moles isa BigFloat
+        @test isapprox(Float64(moles), 0.05853314527503526; rtol=1e-10)
+
+        # Test theoretical_yield with BigFloat
+        yield = theoretical_yield(reaction, masses_bf, AlCl3)
+        @test yield isa BigFloat
+        @test isapprox(Float64(yield), 5.203206393982134; rtol=1e-10)
+    end
+
+    @testset "Float32 support" begin
+        # Test limiting_reagent with Float32
+        masses_f32 = Float32[2.80, 4.15]
+        lr, moles = limiting_reagent(reaction, masses_f32)
+        @test isequal(lr, Cl2)
+        @test isapprox(moles, 0.05853314527503526; rtol=1e-5)
+
+        # Test theoretical_yield with Float32
+        yield = theoretical_yield(reaction, masses_f32, AlCl3)
+        @test isapprox(yield, 5.203206393982134; rtol=1e-5)
+    end
+
+    @testset "Float64 support (baseline)" begin
+        # Test limiting_reagent with Float64
+        masses_f64 = [2.80, 4.15]
+        lr, moles = limiting_reagent(reaction, masses_f64)
+        @test isequal(lr, Cl2)
+        @test moles isa Float64
+        @test isapprox(moles, 0.05853314527503526; rtol=1e-10)
+
+        # Test theoretical_yield with Float64
+        yield = theoretical_yield(reaction, masses_f64, AlCl3)
+        @test yield isa Float64
+        @test isapprox(yield, 5.203206393982134; rtol=1e-10)
+    end
+
+    @testset "moles_by_volume with BigFloat" begin
+        result = moles_by_volume(BigFloat("0.300"), BigFloat("0.400"))
+        @test result isa BigFloat
+        @test isapprox(Float64(result), 0.12; rtol=1e-10)
+    end
+
+    @testset "moles_by_mass with BigFloat" begin
+        @species MnO2(t)
+        @attach_metadata MnO2
+
+        result = moles_by_mass(MnO2, BigFloat("95"))
+        @test result isa BigFloat
+        @test isapprox(Float64(result), 1.0927453213246374; rtol=1e-10)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,9 @@ const GROUP = get(ENV, "GROUP", "all")
         @time @safetestset "Chemistry" begin
             include("functions.jl")
         end
+        @time @safetestset "Type Genericity" begin
+            include("interface_tests.jl")
+        end
     end
 
     if GROUP == "all" || GROUP == "nopre"


### PR DESCRIPTION
## Summary

This PR improves interface compliance with Julia's SciML array/number interfaces by removing hardcoded type constraints.

### Changes

- **`limiting_reagent`**: Changed parameter type from `Array{Float64}` to `AbstractVector` to support BigFloat, Float32, and other numeric types
- **`theoretical_yield`**: Changed parameter type from `Array` to `AbstractVector` for consistency with `limiting_reagent`
- Added `test/interface_tests.jl` with comprehensive tests for type genericity

### Testing Performed

Tested with:
- **BigFloat**: Works correctly, returns BigFloat results with full precision
- **Float32**: Works correctly
- **Float64 (baseline)**: Continues to work as before
- **JLArrays (GPU-like)**: Does not work due to scalar indexing requirement (this is expected behavior for the current algorithm design)

### Interface Compliance Notes

The functions now accept any `AbstractVector` element type, enabling:
1. Arbitrary precision arithmetic with BigFloat
2. Reduced precision with Float32
3. Custom numeric types

Note: GPU arrays (like JLArrays or CUDA arrays) are not supported because `limiting_reagent` uses scalar indexing to find the minimum. This is a fundamental algorithm constraint, not an interface issue.

## Test plan

- [ ] Verify existing tests pass
- [ ] Verify new interface tests pass
- [ ] Confirm BigFloat works correctly with chemistry functions

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)