### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,20 +7,26 @@ authors = ["Lalit Chauhan"]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [compat]
 AllocCheck = "0.2"
 Catalyst = "13, 14"
+ExplicitImports = "1"
 HTTP = "1.9.6"
 JSON = "0.21.4"
+ModelingToolkit = "9"
 SymbolicUtils = "1.7.1, 2, 3"
+Symbolics = "6"
 julia = "1.9"
 
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SafeTestsets", "AllocCheck"]
+test = ["Test", "SafeTestsets", "AllocCheck", "ExplicitImports"]

--- a/src/PubChem.jl
+++ b/src/PubChem.jl
@@ -1,7 +1,9 @@
 module PubChem
-using HTTP
-using JSON
-using Catalyst
+using HTTP: HTTP
+using JSON: JSON
+using Catalyst: Catalyst, Reaction
+using ModelingToolkit: ModelingToolkit
+using Symbolics: Symbolics, Num
 using SymbolicUtils: BasicSymbolic
 
 include("JSON_data.jl")

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,0 +1,8 @@
+using ExplicitImports
+using PubChem
+using Test
+
+@testset "ExplicitImports" begin
+    @test check_no_implicit_imports(PubChem) === nothing
+    @test check_no_stale_explicit_imports(PubChem) === nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,9 @@ const GROUP = get(ENV, "GROUP", "all")
         @time @safetestset "Type Genericity" begin
             include("interface_tests.jl")
         end
+        @time @safetestset "Explicit Imports" begin
+            include("explicit_imports.jl")
+        end
     end
 
     if GROUP == "all" || GROUP == "nopre"


### PR DESCRIPTION
## Summary

This PR improves the package's import hygiene by replacing implicit imports with explicit ones:

- Replace `using Package` with `using Package: Package` for HTTP, JSON, Catalyst
- Add explicit imports for `Num` (Symbolics), `Reaction` (Catalyst), and `ModelingToolkit`
- Add `ModelingToolkit` and `Symbolics` as explicit dependencies in Project.toml (previously only accessed transitively through Catalyst)
- Add ExplicitImports.jl to test dependencies with CI test
- Create `test/explicit_imports.jl` that validates no implicit imports

### Files changed:
- `src/PubChem.jl`: Updated import statements
- `Project.toml`: Added ModelingToolkit, Symbolics deps; ExplicitImports test dep
- `test/runtests.jl`: Added ExplicitImports test
- `test/explicit_imports.jl`: New test file

### Why this matters:
This ensures the package doesn't rely on transitive dependencies (names re-exported by Catalyst that actually come from ModelingToolkit or Symbolics). Following best practices for explicit imports prevents breakage when upstream packages change their re-exports.

## Test plan
- [x] `check_no_implicit_imports(PubChem)` passes
- [x] `check_no_stale_explicit_imports(PubChem)` passes
- [x] Allocation tests pass
- [x] ExplicitImports tests pass
- [ ] Full CI passes (network-based tests may be flaky due to PubChem API rate limiting)

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)