### PR TITLE
Documentation improvements: Fix grammar and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Dict{Any, Any} with 7 entries:
   "Smiles"                 => "O"
 ```
 
-You can also query the properties directly, by name by CID or by Formula, even if you are not using Catalyst.
+You can also query the properties directly, by name, by CID, or by formula, even if you are not using Catalyst.
 This fetches it from PubChem directly.
 
 ```julia
@@ -73,24 +73,23 @@ With metadata attached to species directly, you can now utilize these chemical p
 As an example, let's consider the reaction `2Al + 3Cl2 --> 2AlCl3` and suppose we have the masses of `Al` and `Cl2` as 2.80g and 4.15g, respectively.
 
 ```julia
-julia> limiting_reagent(rx, [2.80, 4.15])
 @variables t
 @species Al(t), Cl2(t), AlCl3(t)
 
 # Attach metadata to the species
-@attach_metadata Al 
-@attach_metadata Cl2 
-@attach_metadata AlCl3 
+@attach_metadata Al
+@attach_metadata Cl2
+@attach_metadata AlCl3
 
-# Define a balanced Catalyst reaction 
+# Define a balanced Catalyst reaction
 rx = Reaction(1.0, [Al, Cl2], [AlCl3], [2, 3], [2])
 
 # Get limiting reagent given the masses of the reactants
-
-julia> theoretical_yield(rx, [2.80, 4.15], AlCl3)
-(Cl2(t), 0.05853314527503526) # Returns the limiting reagent and it's number of moles
+julia> limiting_reagent(rx, [2.80, 4.15])
+(Cl2(t), 0.05853314527503526) # Returns the limiting reagent and its number of moles
 
 # Calculate theoretical yield given the masses of the reactants and the product for which to calculate
+julia> theoretical_yield(rx, [2.80, 4.15], AlCl3)
 ```
 
 ## See also

--- a/docs/src/basic_usage/attach_metadata_macro.md
+++ b/docs/src/basic_usage/attach_metadata_macro.md
@@ -51,7 +51,7 @@ The chemical properties of `H2O` have now been attached to `X`.
 chemical_properties(X)
 ```
 
-Similary, we can use the CID of the species when the name of the species is complex or difficult to work with.
+Similarly, we can use the CID of the species when the name of the species is complex or difficult to work with.
 
 ```@example ind3
 using PubChem, Catalyst

--- a/docs/src/basic_usage/querying_data.md
+++ b/docs/src/basic_usage/querying_data.md
@@ -67,7 +67,7 @@ IUPAC_Name_Traditional(CH3COOH)
 
 ## Querying Directly
 
-All of the above methods work with named, CIDs, or formula as well.
+All of the above methods work with names, CIDs, or formulas as well.
 
 ```@example direct_query
 using PubChem

--- a/docs/src/chemical_calculations/chemical_calculations.md
+++ b/docs/src/chemical_calculations/chemical_calculations.md
@@ -35,7 +35,7 @@ The chemical reaction should be balanced.
 We can then calculate the limiting reagent, provided we have the masses of the reactants.
 
 ```@example ind1
-limiting_reagent(rx, [2.80, 4.15])  # Returns the limiting reagent and it's number of moles
+limiting_reagent(rx, [2.80, 4.15])  # Returns the limiting reagent and its number of moles
 ```
 
 ## Determining Theoretical Yield
@@ -48,7 +48,7 @@ theoretical_yield(rx, [2.80, 4.15], AlCl3) # theoretical yield in grams
 
 ## Calculating Molar Ratios in a Reaction
 
-We can calculate the molar ratios of two species involved in a reaction. If we want to calcuate the molar ratio of `Al` and `AlCl3` in the above reaction, we can do the following:
+We can calculate the molar ratios of two species involved in a reaction. If we want to calculate the molar ratio of `Al` and `AlCl3` in the above reaction, we can do the following:
 
 ```@example ind1
 molar_ratio(rx, Al, AlCl3)

--- a/src/JSON_data.jl
+++ b/src/JSON_data.jl
@@ -104,7 +104,7 @@ end
 """
     @attach_metadata
 
-Attach chemical properties fetched from PubChem to the given speices
+Attach chemical properties fetched from PubChem to the given species.
 
 Example:
 ```julia

--- a/src/Retrieve.jl
+++ b/src/Retrieve.jl
@@ -2,8 +2,8 @@
     chemical_properties(species)
 
 Return the chemical properties for a species.
-If the species is given as a symbolic variable from Catalyst, this checks the metadata, attached to the species.
-If it is given as string then PubChem is queries by name, if it is given as an integer then pubchem is queried by CID.
+If the species is given as a symbolic variable from Catalyst, this checks the metadata attached to the species.
+If it is given as a string, then PubChem is queried by name; if it is given as an integer, then PubChem is queried by CID.
 """
 
 chemical_properties(s::Num) = chemical_properties(ModelingToolkit.value(s))


### PR DESCRIPTION
## Summary

This PR fixes multiple grammar and typo issues across the documentation to improve clarity and readability.

## Changes Made

### README.md
- Fixed punctuation: "by name by CID or by Formula" → "by name, by CID, or by formula"
- Reordered example code for better clarity (code before output)
- Fixed possessive: "it's number of moles" → "its number of moles"
- Removed trailing whitespace

### Documentation Files
- **docs/src/basic_usage/querying_data.md**: Fixed "named, CIDs, or formula" → "names, CIDs, or formulas"
- **docs/src/basic_usage/attach_metadata_macro.md**: Fixed typo "Similary" → "Similarly"
- **docs/src/chemical_calculations/chemical_calculations.md**: 
  - Fixed possessive "it's" → "its"
  - Fixed typo "calcuate" → "calculate"

### Source Code Docstrings
- **src/Retrieve.jl**: 
  - Fixed "PubChem is queries" → "PubChem is queried"
  - Improved grammar and punctuation in docstring
- **src/JSON_data.jl**: Fixed typo "speices" → "species"

All changes are purely cosmetic improvements to documentation and comments. No code logic was modified.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)