### PR TITLE
Fix Downgrade lane: use public HTTP.get instead of piracy-dependent Base.get

### DIFF
--- a/src/JSON_data.jl
+++ b/src/JSON_data.jl
@@ -1,10 +1,8 @@
 struct CompoundProperties end
 Symbolics.option_to_metadata_type(::Val{:properties}) = CompoundProperties
 
-# Send HTTP request to API. HTTP adds its GET-request method to `Base.get`,
-# so we call through the owning module (`Base.get`) rather than `HTTP.get`.
 function get_json_from_url(url)
-    resp = Base.get(url)
+    resp = HTTP.get(url)
     return JSON.parse(String(resp.body))
 end
 


### PR DESCRIPTION
## Summary

The `Downgrade` CI lane fails at the `HTTP` compat floor (`1.9.6`). `get_json_from_url` in `src/JSON_data.jl` called `Base.get(url)`:

```julia
# Send HTTP request to API. HTTP adds its GET-request method to `Base.get`,
# so we call through the owning module (`Base.get`) rather than `HTTP.get`.
function get_json_from_url(url)
    resp = Base.get(url)
    return JSON.parse(String(resp.body))
end
```

This only works because newer HTTP.jl (2.x) **pirates** `Base.get`. That is an undocumented incidental piracy that is **absent at the 1.9.6 floor**, so on the Downgrade lane `Base.get(url)` dispatches to Base's own `get` and throws `MethodError: no method matching get(::String)`.

## Fix

Call HTTP.jl's documented public verb `HTTP.get` instead:

```julia
function get_json_from_url(url)
    resp = HTTP.get(url)
    return JSON.parse(String(resp.body))
end
```

`HTTP.get`:
- exists in **every** supported version (`1.9.6` through `2.2`);
- returns a response with `.body` (the contract already relied on here);
- throws `HTTP.RequestError` / `HTTP.Exceptions.StatusError`, both already handled in `get_compound`.

`HTTP` is already imported via `using HTTP: HTTP` in `src/PubChem.jl`, so no import / `Project.toml` / compat change is needed. This is the only `Base.get`/`.get(` occurrence in `src/`.

Note: bumping the `HTTP` compat floor was deliberately **not** done — that would rely on the `Base.get` piracy and needlessly restrict compat. The public-API call `HTTP.get` is the correct fix.

## Validation (local, HTTP pinned to the compat floor 1.9.6 on Julia 1.10.11)

- Reproduced the failure: with `HTTP` pinned to `1.9.6`, `Base.get(url)` throws `MethodError: no method matching get(::String)` (confirming the piracy is absent at the floor).
- Confirmed `HTTP.get` exists at `1.9.6` (`isdefined(HTTP, :get) == true`).
- End-to-end with the fixed function at the floor: `get_json_from_url` returns parsed JSON from a real request; the exact PubChem endpoint (`.../compound/name/water/json`) returns valid `PC_Compounds` JSON.
- `Runic` check on `src/JSON_data.jl`: clean (no diff).

## Note

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)