### PR TITLE
Bump version to 1.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PubChem"
 uuid = "1db272ca-bb6a-4d7c-9426-e93aef723262"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["Lalit Chauhan"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (1.2.1 -> 1.2.2) to release unreleased commits on `master` via JuliaRegistrator.