### PR TITLE
Release prep: bump to 1.2.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PubChem"
 uuid = "1db272ca-bb6a-4d7c-9426-e93aef723262"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Lalit Chauhan"]
 
 [deps]


### PR DESCRIPTION
Version-bump-only release PR. Swaps HTTP.jl for stdlib Downloads with added retry-on-5xx logic; error type surfaced to callers changes from HTTP.Exceptions to Downloads.RequestError.